### PR TITLE
added newsfeed section, embedded roalddahl facebook page

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -90,3 +90,16 @@
 .product-section div {
   padding: 20px;
 }
+
+/*--------  EMBED SECTION ---------*/
+
+.facebook-embed {
+  margin: 50px 0;
+  padding: 20px;
+  border-top: 3px #efefef dashed;
+  text-align: center;
+}
+
+.facebook-embed h3 {
+  color: #ccc;
+}

--- a/index.html
+++ b/index.html
@@ -109,6 +109,13 @@
 <script async src="//cdn.embedly.com/widgets/platform.js" charset="UTF-8"></script>
         </div>
       </section>
+
+      <!-- Facebook embed section -->
+      <section class="col-xs-12 facebook-embed">
+        <h2>What's Roald is Gold</h2>
+        <h3>check out some fun RD happenings below!</h3>
+        <div class="fb-page embed-responsive-item" data-href="https://www.facebook.com/roalddahl" data-tabs="timeline" data-width="500" data-height="700" data-small-header="false" data-adapt-container-width="true" data-hide-cover="false" data-show-facepile="true"><blockquote cite="https://www.facebook.com/roalddahl" class="fb-xfbml-parse-ignore"><a href="https://www.facebook.com/roalddahl">Roald Dahl</a></blockquote></div>
+      </section>
       <footer>
         <p>&copy; RDF Poetry 2016</p>
       </footer>


### PR DESCRIPTION
References Issue: https://github.com/suwebdev/sparkling-art/issues/16

This change doesn't require any additional dependencies. It uses data pulled from Facebook's developer API, specifically the `<blockquote>` powered newsfeed embed. 

Similar to my pull request for the collateral section, Bootstraps pre-styling of the `<blockquote>` tag limits the full newsfeed from being shown.
